### PR TITLE
Add React tests and Jest configuration

### DIFF
--- a/client/src/components/__tests__/Navbar.test.tsx
+++ b/client/src/components/__tests__/Navbar.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import Navbar from '../Navbar';
+
+describe('Navbar', () => {
+  it('contains a link to the Analytics page', () => {
+    render(<Navbar />);
+    const analyticsLink = screen.getByRole('link', { name: /analytics/i });
+    expect(analyticsLink).toHaveAttribute('href', '/analytics');
+  });
+});

--- a/client/src/pages/__tests__/Contact.test.tsx
+++ b/client/src/pages/__tests__/Contact.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Contact from '../Contact';
+
+describe('Contact page', () => {
+  it('submits the contact form', async () => {
+    const user = userEvent.setup();
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    render(<Contact />);
+
+    await user.type(screen.getByLabelText(/your name/i), 'John Doe');
+    await user.type(screen.getByLabelText(/email address/i), 'john@example.com');
+    await user.type(screen.getByLabelText(/subject/i), 'Quote');
+    await user.type(screen.getByLabelText(/your message/i), 'Hello');
+    await user.selectOptions(screen.getByLabelText(/service interest/i), ['warehousing']);
+
+    await user.click(screen.getByRole('button', { name: /send message/i }));
+
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});

--- a/client/src/pages/__tests__/Home.test.tsx
+++ b/client/src/pages/__tests__/Home.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react';
+import Home from '../Home';
+
+describe('Home page', () => {
+  it('renders hero heading', () => {
+    render(<Home />);
+    expect(
+      screen.getByRole('heading', {
+        name: /E-Commerce Experience/i,
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/client/src/$1',
+    '^@shared/(.*)$': '<rootDir>/shared/$1'
+  },
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testMatch: ['**/*.test.ts?(x)']
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -100,7 +101,13 @@
     "tailwindcss": "^3.4.14",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "@testing-library/react": "^14.0.0",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "jest-environment-jsdom": "^29.7.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"


### PR DESCRIPTION
## Summary
- add Jest config and setup
- create basic unit tests for Home, Contact, and Navbar components
- update `package.json` to include test script and dev dependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_683dd9912b9c833099ec11fd550bc9d7