### PR TITLE
Add analytics feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+ANALYTICS_ENABLED=true
+VITE_ANALYTICS_ENABLED=true
+DATABASE_URL=postgres://user:password@host:5432/db

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ const IndustryDetail = lazy(() => import("@/pages/IndustryDetail"));
 const About = lazy(() => import("@/pages/About"));
 const Contact = lazy(() => import("@/pages/Contact"));
 const Locations = lazy(() => import("@/pages/Locations"));
+const analyticsEnabled = import.meta.env.VITE_ANALYTICS_ENABLED === 'true';
 const Analytics = lazy(() => import("@/pages/Analytics"));
 const ReportGenerator = lazy(() => import("@/pages/ReportGenerator"));
 const PerformanceComparison = lazy(() => import("@/pages/PerformanceComparison"));
@@ -66,10 +67,14 @@ function Router() {
         <Route path="/about" component={About} />
         <Route path="/contact" component={Contact} />
         <Route path="/locations" component={Locations} />
-        <Route path="/analytics" component={Analytics} />
-        <Route path="/analytics/reports" component={ReportGenerator} />
-        <Route path="/analytics/comparison" component={PerformanceComparison} />
-        <Route path="/analytics/dashboard" component={CustomDashboard} />
+        {analyticsEnabled && (
+          <>
+            <Route path="/analytics" component={Analytics} />
+            <Route path="/analytics/reports" component={ReportGenerator} />
+            <Route path="/analytics/comparison" component={PerformanceComparison} />
+            <Route path="/analytics/dashboard" component={CustomDashboard} />
+          </>
+        )}
         <Route path="/admin/images" component={ImageManagement} />
         <Route path="/test/quote-buttons" component={QuoteButtonTest} />
         <Route path="/quote" component={QuoteRequest} />

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -3,6 +3,8 @@ import { Link } from 'wouter';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/hooks/use-toast';
 import Logo from './Logo';
+
+const analyticsEnabled = import.meta.env.VITE_ANALYTICS_ENABLED === 'true';
 import {
   Sheet,
   SheetContent,
@@ -71,9 +73,9 @@ const Navbar: React.FC = () => {
     { label: 'Contact', id: 'contact-form', isLink: true }
   ];
   
-  const pageLinks = [
-    { label: 'Analytics', href: '/analytics' }
-  ];
+  const pageLinks = analyticsEnabled
+    ? [{ label: 'Analytics', href: '/analytics' }]
+    : [];
 
   return (
     <>

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,8 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 import { seedAnalyticsData } from "./seed-data";
 
+const analyticsEnabled = process.env.ANALYTICS_ENABLED === "true";
+
 const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
@@ -38,7 +40,7 @@ app.use((req, res, next) => {
 });
 
 (async () => {
-  const server = await registerRoutes(app);
+  const server = await registerRoutes(app, analyticsEnabled);
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;
@@ -57,11 +59,12 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // Seed analytics data for demo purposes
-  try {
-    await seedAnalyticsData();
-  } catch (error) {
-    log(`Error seeding analytics data: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  if (analyticsEnabled) {
+    try {
+      await seedAnalyticsData();
+    } catch (error) {
+      log(`Error seeding analytics data: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
   }
 
   // ALWAYS serve the app on port 5000

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -13,13 +13,15 @@ import {
 // Error handler utility function
 const handleError = (res: Response, error: any, message: string = 'An error occurred') => {
   console.error(`Error: ${message}`, error);
-  res.status(400).json({ 
+  res.status(400).json({
     message,
     error: error instanceof Error ? error.message : 'Unknown error'
   });
 };
 
-export async function registerRoutes(app: Express): Promise<Server> {
+const analyticsEnabled = process.env.ANALYTICS_ENABLED === 'true';
+
+export async function registerRoutes(app: Express, analytics: boolean): Promise<Server> {
   // QUOTE REQUEST ENDPOINTS
   // Create a quote request
   app.post('/api/quote-requests', async (req, res) => {
@@ -372,9 +374,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
   
-  // ANALYTICS API ENDPOINTS
-  // Get client analytics summary
-  app.get('/api/analytics/client-summary/:clientId', async (req, res) => {
+  if (analytics) {
+    // ANALYTICS API ENDPOINTS
+    // Get client analytics summary
+    app.get('/api/analytics/client-summary/:clientId', async (req, res) => {
     try {
       const clientId = parseInt(req.params.clientId);
       const analyticsSummary = await storage.getClientAnalyticsSummary(clientId);
@@ -382,10 +385,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       handleError(res, error, 'Error retrieving client analytics summary');
     }
-  });
+    });
   
-  // Get shipping performance analytics
-  app.get('/api/analytics/shipping-performance', async (req, res) => {
+    // Get shipping performance analytics
+    app.get('/api/analytics/shipping-performance', async (req, res) => {
     try {
       const clientId = req.query.clientId ? parseInt(req.query.clientId as string) : undefined;
       const startDate = req.query.startDate ? new Date(req.query.startDate as string) : undefined;
@@ -396,10 +399,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       handleError(res, error, 'Error retrieving shipping performance');
     }
-  });
+    });
   
-  // Get inventory report
-  app.get('/api/analytics/inventory-report', async (req, res) => {
+    // Get inventory report
+    app.get('/api/analytics/inventory-report', async (req, res) => {
     try {
       const clientId = req.query.clientId ? parseInt(req.query.clientId as string) : undefined;
       const inventoryReport = await storage.getInventoryReport(clientId);
@@ -407,11 +410,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       handleError(res, error, 'Error retrieving inventory report');
     }
-  });
+    });
   
-  // Advanced analytics endpoints
-  // Get report data for customized reports
-  app.get('/api/analytics/report-data', async (req, res) => {
+    // Advanced analytics endpoints
+    // Get report data for customized reports
+    app.get('/api/analytics/report-data', async (req, res) => {
     try {
       const clientId = req.query.clientId ? parseInt(req.query.clientId as string) : undefined;
       const reportType = req.query.reportType as string;
@@ -427,10 +430,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       handleError(res, error, 'Error retrieving report data');
     }
-  });
+    });
   
-  // Get comparison data for performance analytics
-  app.get('/api/analytics/comparison', async (req, res) => {
+    // Get comparison data for performance analytics
+    app.get('/api/analytics/comparison', async (req, res) => {
     try {
       const { clientId, periodAStart, periodAEnd, periodBStart, periodBEnd, metric } = req.query;
       
@@ -452,7 +455,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
     } catch (error) {
       handleError(res, error, 'Error retrieving comparison data');
     }
-  });
+    });
+  }
 
   const httpServer = createServer(app);
 


### PR DESCRIPTION
## Summary
- add `.env.example` with `ANALYTICS_ENABLED` variables
- gate analytics data seeding and endpoints behind a flag
- allow client to hide analytics pages and navbar link via `VITE_ANALYTICS_ENABLED`

## Testing
- `npm install`
- `npm run check` *(fails: several type errors)*
- `npm test` *(fails: ReferenceError in jest.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_683f4db5ad108330b234b48d011b297d