### PR TITLE
Wrap tests with HelmetProvider

### DIFF
--- a/client/src/pages/__tests__/Contact.test.tsx
+++ b/client/src/pages/__tests__/Contact.test.tsx
@@ -2,12 +2,17 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import Contact from '../Contact';
+import HelmetProvider from '@/components/SEO/HelmetProvider';
 
 describe('Contact page', () => {
   it('submits the contact form', async () => {
     const user = userEvent.setup();
     const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    render(<Contact />);
+    render(
+      <HelmetProvider>
+        <Contact />
+      </HelmetProvider>
+    );
 
     await user.type(screen.getByLabelText(/your name/i), 'John Doe');
     await user.type(screen.getByLabelText(/email address/i), 'john@example.com');

--- a/client/src/pages/__tests__/Home.test.tsx
+++ b/client/src/pages/__tests__/Home.test.tsx
@@ -1,9 +1,14 @@
 import { render, screen } from '@testing-library/react';
 import Home from '../Home';
+import HelmetProvider from '@/components/SEO/HelmetProvider';
 
 describe('Home page', () => {
   it('renders hero heading', () => {
-    render(<Home />);
+    render(
+      <HelmetProvider>
+        <Home />
+      </HelmetProvider>
+    );
     expect(
       screen.getByRole('heading', {
         name: /E-Commerce Experience/i,


### PR DESCRIPTION
## Summary
- wrap Home and Contact tests with `<HelmetProvider>` to avoid undefined add errors
- install dependencies for testing

## Testing
- `npm ci`
- `npx vitest run client/src/pages/__tests__/Home.test.tsx client/src/pages/__tests__/Contact.test.tsx` *(fails: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_683f64295bc883308cd7961e81de577c