### PR TITLE
Fix Navbar test env variable

### DIFF
--- a/client/src/components/__tests__/Navbar.test.tsx
+++ b/client/src/components/__tests__/Navbar.test.tsx
@@ -1,8 +1,15 @@
 import { render, screen } from '@testing-library/react';
-import Navbar from '../Navbar';
 
 describe('Navbar', () => {
-  it('contains a link to the Analytics page', () => {
+  beforeAll(() => {
+    process.env.VITE_ANALYTICS_ENABLED = 'true';
+  });
+
+  afterAll(() => {
+    delete process.env.VITE_ANALYTICS_ENABLED;
+  });
+  it('contains a link to the Analytics page', async () => {
+    const { default: Navbar } = await import('../Navbar');
     render(<Navbar />);
     const analyticsLink = screen.getByRole('link', { name: /analytics/i });
     expect(analyticsLink).toHaveAttribute('href', '/analytics');


### PR DESCRIPTION
## Summary
- set `VITE_ANALYTICS_ENABLED` during Navbar tests
- dynamically import Navbar to ensure env variable is read

## Testing
- `npm install`
- `npx vitest run client/src/components/__tests__/Navbar.test.tsx`
- `npx vitest run` *(fails: IntersectionObserver is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_683f657ad160833091e0b147a183adb0