### PR TITLE
Fix quote button tests cleanup

### DIFF
--- a/client/src/__tests__/quote-buttons.test.tsx
+++ b/client/src/__tests__/quote-buttons.test.tsx
@@ -1,7 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
+
+// Preserve original methods so they can be restored after tests
+const originalScrollTo = window.scrollTo;
+const originalGetElementById = document.getElementById;
 
 // Mock scrollTo function
 const mockScrollTo = vi.fn();
@@ -30,6 +34,11 @@ describe('Quote Button Functionality Tests', () => {
       if (id === 'contact') return mockContactElement;
       return null;
     });
+  });
+
+  afterAll(() => {
+    window.scrollTo = originalScrollTo;
+    document.getElementById = originalGetElementById;
   });
 
   describe('Quote Button Click Handlers', () => {


### PR DESCRIPTION
## Summary
- preserve original DOM methods in the quote button test file
- restore mocked methods after all tests

## Testing
- `npm test` *(fails: IntersectionObserver is not defined, Cannot read properties of null (reading 'storage'))*

------
https://chatgpt.com/codex/tasks/task_b_683f7249bfa8833096af21ba2e1a3051