### PR TITLE
Update Navbar test for import.meta env

### DIFF
--- a/client/src/components/__tests__/Navbar.test.tsx
+++ b/client/src/components/__tests__/Navbar.test.tsx
@@ -1,17 +1,32 @@
 import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
 
-describe('Navbar', () => {
+describe.each([
+  { flag: 'true', shouldShowLink: true },
+  { flag: 'false', shouldShowLink: false },
+])('Navbar when VITE_ANALYTICS_ENABLED=%s', ({ flag, shouldShowLink }) => {
   beforeAll(() => {
-    process.env.VITE_ANALYTICS_ENABLED = 'true';
+    process.env.VITE_ANALYTICS_ENABLED = flag;
+    (import.meta as any).env = {
+      ...(import.meta as any).env,
+      VITE_ANALYTICS_ENABLED: flag,
+    };
   });
 
   afterAll(() => {
     delete process.env.VITE_ANALYTICS_ENABLED;
+    delete (import.meta as any).env.VITE_ANALYTICS_ENABLED;
   });
-  it('contains a link to the Analytics page', async () => {
+
+  it(`${shouldShowLink ? 'contains' : 'does not contain'} a link to the Analytics page`, async () => {
+    vi.resetModules();
     const { default: Navbar } = await import('../Navbar');
     render(<Navbar />);
-    const analyticsLink = screen.getByRole('link', { name: /analytics/i });
-    expect(analyticsLink).toHaveAttribute('href', '/analytics');
+    const analyticsLink = screen.queryByRole('link', { name: /analytics/i });
+    if (shouldShowLink) {
+      expect(analyticsLink).toHaveAttribute('href', '/analytics');
+    } else {
+      expect(analyticsLink).toBeNull();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- extend Navbar test to set both `process.env` and `import.meta.env`
- verify Analytics link visibility for enabled/disabled states

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683f76e36ebc833082527152dc899b56