### PR TITLE
Add vitest test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",


### PR DESCRIPTION
## Summary
- expose Vitest via `npm run test` by adding script

## Testing
- `npm run test` *(fails: Cannot find package '@shared/schema' imported from server/routes.ts)*

------
https://chatgpt.com/codex/tasks/task_b_683fd948d57083308e2edc5faf3ca123