### PR TITLE
Add shared alias to vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './client/src'),
+      '@shared': path.resolve(__dirname, './shared'),
     },
   },
 });


### PR DESCRIPTION
## Summary
- add `@shared` alias to Vitest config to resolve shared module path

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68402ab5259c8330a409497289b8a524