### PR TITLE
Add Playwright e2e setup

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -25,6 +25,18 @@ npx vitest run --coverage
 
 The global report should show at least **98%** coverage for lines, branches, functions and statements.
 
+## End-to-End Tests
+
+End-to-end tests live in the `e2e` directory and are powered by [Playwright](https://playwright.dev/).
+
+Run them with:
+
+```bash
+npm run e2e
+```
+
+This uses the configuration defined in `playwright.config.ts`.
+
 ## Interpreting Results
 
 - When all tests pass, the command exits with code `0` and displays success messages for each suite.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -29,6 +29,18 @@ The global report should show at least **98%** coverage for lines, branches, fun
 
 End-to-end tests live in the `e2e` directory and are powered by [Playwright](https://playwright.dev/).
 
+### Prerequisites for E2E Tests
+
+Before running e2e tests, you need to install the browser executables:
+
+```bash
+npx playwright install
+```
+
+**Note:** The first time you run e2e tests, you may encounter an error about missing browser executables. Run the install command above to resolve this.
+
+### Running E2E Tests
+
 Run them with:
 
 ```bash
@@ -36,6 +48,22 @@ npm run e2e
 ```
 
 This uses the configuration defined in `playwright.config.ts`.
+
+### E2E Test Configuration
+
+The Playwright configuration (`playwright.config.ts`) includes:
+- Test directory: `e2e/`
+- Test file pattern: `**/*.e2e.ts`
+- Base URL: `http://localhost:5000`
+- Reporters: list and HTML (HTML report saved but not auto-opened)
+
+### E2E Test Development
+
+E2E tests should:
+- Use the `.e2e.ts` file extension
+- Be placed in the `e2e/` directory
+- Target the local development server at `http://localhost:5000`
+- Follow Playwright testing patterns and best practices
 
 ## Interpreting Results
 

--- a/e2e/quote.e2e.ts
+++ b/e2e/quote.e2e.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test('submit quote form', async ({ page }) => {
-  await page.goto('http://localhost:5000/quote');
+  await page.goto('/quote');
   await page.fill('input[placeholder="Name *"]', 'John');
   await page.fill('input[placeholder="Business Email *"]', 'john@example.com');
   await page.fill('input[placeholder="Mobile Number *"]', '1234567890');

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.52.0",
         "@replit/vite-plugin-cartographer": "^0.2.7",
         "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
@@ -1625,6 +1626,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "test": "vitest run",
-    "e2e": "playwright test"
+    "e2e": "npx playwright install --with-deps && playwright test",
+    "e2e:install": "npx playwright install --with-deps"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
-    "test": "vitest run"
+    "test": "vitest run",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -104,6 +105,7 @@
     "drizzle-kit": "^0.30.4",
     "esbuild": "^0.25.0",
     "playwright": "^1.52.0",
+    "@playwright/test": "^1.52.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "tsx": "^4.19.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'e2e',
+  testMatch: '**/*.e2e.ts',
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:5000',
+  },
+});


### PR DESCRIPTION
## Summary
- configure Playwright with `playwright.config.ts`
- add `e2e` npm script and install `@playwright/test`
- document how to run e2e tests

## Testing
- `npm run test`
- `npm run e2e` *(fails: browser executables missing)*

------
https://chatgpt.com/codex/tasks/task_b_684034f846688330b84ddb70181a0b2c