### PR TITLE
Add tests for index analytics and error flow

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -25,6 +25,25 @@ npx vitest run --coverage
 
 The global report should show at least **98%** coverage for lines, branches, functions and statements.
 
+## Test Suites
+
+### Server Tests
+
+- **`server/__tests__/index.test.ts`** - Integration tests for the main server entry point, verifying:
+  - Analytics initialization and setup
+  - Server listening on port 5000
+  - Error propagation through Express middleware
+- **`server/__tests__/routes.test.ts`** - API route functionality tests
+- **`server/__tests__/storage.test.ts`** - Storage layer tests
+- **`server/__tests__/integration.test.tsx`** - Full integration tests with React components
+
+### Client Tests
+
+- **`client/src/__tests__/`** - Component and utility tests
+- **`client/src/components/__tests__/`** - UI component tests
+- **`client/src/hooks/__tests__/`** - Custom hook tests
+- **`client/src/lib/__tests__/`** - Library utility tests
+
 ## Interpreting Results
 
 - When all tests pass, the command exits with code `0` and displays success messages for each suite.

--- a/server/__tests__/index.test.ts
+++ b/server/__tests__/index.test.ts
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment node
+ */
+import { vi, beforeEach, afterEach, it, expect } from 'vitest';
+import type { Express } from 'express';
+import http from 'http';
+
+let serverInstance: http.Server;
+
+const registerRoutesMock = vi.fn(async (app: Express, _analytics: boolean) => {
+  app.get('/error', () => {
+    throw new Error('boom');
+  });
+  serverInstance = http.createServer(app as any);
+  return serverInstance;
+});
+
+const seedAnalyticsDataMock = vi.fn();
+
+vi.mock('../routes', () => ({ registerRoutes: registerRoutesMock }));
+vi.mock('../seed-data', () => ({ seedAnalyticsData: seedAnalyticsDataMock }));
+vi.mock('../vite', () => ({
+  setupVite: vi.fn(),
+  serveStatic: vi.fn(),
+  log: vi.fn(),
+}));
+
+beforeEach(() => {
+  process.env.ANALYTICS_ENABLED = 'true';
+  process.env.NODE_ENV = 'production';
+});
+
+afterEach(async () => {
+  if (serverInstance?.listening) {
+    await new Promise<void>((r) => serverInstance.close(() => r()));
+  }
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+it('initializes server with analytics and propagates errors', async () => {
+  await import('../index');
+  await new Promise((r) => serverInstance.on('listening', r));
+
+  expect(registerRoutesMock).toHaveBeenCalledWith(expect.anything(), true);
+  expect(seedAnalyticsDataMock).toHaveBeenCalled();
+  expect((serverInstance.address() as any).port).toBe(5000);
+
+  const res = await fetch('http://localhost:5000/error');
+  expect(res.status).toBe(500);
+});


### PR DESCRIPTION
## Summary
- add integration test for `server/index.ts` to ensure analytics setup
- verify server listens on port `5000`
- assert errors propagate to Express error middleware

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_684034f9620083308e65336577e3ed36