### PR TITLE
Unify contact form route

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,7 +13,6 @@ const OWDStyleHome = lazy(() => import("@/pages/OWDStyleHome"));
 const ServiceDetail = lazy(() => import("@/pages/ServiceDetail"));
 const IndustryDetail = lazy(() => import("@/pages/IndustryDetail"));
 const About = lazy(() => import("@/pages/About"));
-const Contact = lazy(() => import("@/pages/Contact"));
 const Locations = lazy(() => import("@/pages/Locations"));
 const analyticsEnabled = import.meta.env.VITE_ANALYTICS_ENABLED === 'true';
 const Analytics = lazy(() => import("@/pages/Analytics"));
@@ -22,7 +21,6 @@ const PerformanceComparison = lazy(() => import("@/pages/PerformanceComparison")
 const CustomDashboard = lazy(() => import("@/pages/CustomDashboard"));
 const ImageManagement = lazy(() => import("@/pages/image-management"));
 const QuoteButtonTest = lazy(() => import("@/pages/QuoteButtonTest"));
-const QuoteRequest = lazy(() => import("@/pages/QuoteRequest"));
 const ContactForm = lazy(() => import("@/pages/ContactForm"));
 const NotFound = lazy(() => import("@/pages/not-found"));
 
@@ -65,7 +63,6 @@ function Router() {
         <Route path="/services/:slug" component={ServiceDetail} />
         <Route path="/industries/:slug" component={IndustryDetail} />
         <Route path="/about" component={About} />
-        <Route path="/contact" component={Contact} />
         <Route path="/locations" component={Locations} />
         {analyticsEnabled && (
           <>
@@ -77,7 +74,6 @@ function Router() {
         )}
         <Route path="/admin/images" component={ImageManagement} />
         <Route path="/test/quote-buttons" component={QuoteButtonTest} />
-        <Route path="/quote" component={QuoteRequest} />
         <Route path="/contact-form" component={ContactForm} />
         <Route component={NotFound} />
       </Switch>

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -43,7 +43,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
           </div>
           <div className="flex items-center space-x-4">
             <a href="/login" className="hover:text-blue-200 transition-colors">Client Login</a>
-            <a href="/contact" className="hover:text-blue-200 transition-colors">Contact Us</a>
+            <a href="/contact-form" className="hover:text-blue-200 transition-colors">Contact Us</a>
           </div>
         </div>
       </div>
@@ -303,7 +303,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                   </Link>
                 </li>
                 <li>
-                  <Link href="/contact">
+                  <Link href="/contact-form">
                     <a className="text-gray-400 hover:text-white transition-colors">Contact Us</a>
                   </Link>
                 </li>
@@ -330,7 +330,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
                 </li>
               </ul>
               <div className="mt-6">
-                <Link href="/quote">
+                <Link href="/contact-form">
                   <Button className="bg-[#0056B3] hover:bg-[#004494] text-white px-6">
                     Request a Quote
                   </Button>

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -20,7 +20,7 @@ const Navbar: React.FC = () => {
   const [mobileSubmenuOpen, setMobileSubmenuOpen] = useState<string | null>(null);
 
   const handleGetQuote = () => {
-    window.location.href = '/quote';
+    window.location.href = '/contact-form';
   };
 
   useEffect(() => {

--- a/client/src/hooks/__tests__/use-intersection-observer.test.tsx
+++ b/client/src/hooks/__tests__/use-intersection-observer.test.tsx
@@ -8,11 +8,12 @@ describe('useIntersectionObserver', () => {
     let callback: any;
     const observe = vi.fn();
     const unobserve = vi.fn();
+    const disconnect = vi.fn();
     class MockObserver {
       constructor(cb: any) { callback = cb; }
       observe = observe;
       unobserve = unobserve;
-      disconnect = vi.fn();
+      disconnect = disconnect;
     }
     (globalThis as any).IntersectionObserver = MockObserver;
 
@@ -24,6 +25,6 @@ describe('useIntersectionObserver', () => {
     expect(result.current[1]).toBe(true);
 
     unmount();
-    expect(MockObserver.prototype.disconnect).toHaveBeenCalled();
+    expect(disconnect).toHaveBeenCalled();
   });
 });

--- a/client/src/hooks/__tests__/use-toast.test.tsx
+++ b/client/src/hooks/__tests__/use-toast.test.tsx
@@ -1,8 +1,10 @@
 import { renderHook, act } from '@testing-library/react';
 import { vi, expect, describe, it, beforeEach } from 'vitest';
+import { resetToasts } from '../use-toast';
 
 beforeEach(() => {
   vi.clearAllMocks();
+  resetToasts();
 });
 
 describe('useToast hook', () => {

--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -5,7 +5,7 @@ import type {
   ToastProps,
 } from "@/components/ui/toast"
 
-const TOAST_LIMIT = 1
+const TOAST_LIMIT = 3
 const TOAST_REMOVE_DELAY = 1000000
 
 type ToasterToast = ToastProps & {
@@ -76,7 +76,7 @@ export const reducer = (state: State, action: Action): State => {
     case "ADD_TOAST":
       return {
         ...state,
-        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+        toasts: [...state.toasts, action.toast].slice(-TOAST_LIMIT),
       }
 
     case "UPDATE_TOAST":
@@ -137,6 +137,12 @@ function dispatch(action: Action) {
   })
 }
 
+function resetToasts() {
+  memoryState = { toasts: [] }
+  toastTimeouts.forEach((timeout) => clearTimeout(timeout))
+  toastTimeouts.clear()
+}
+
 type Toast = Omit<ToasterToast, "id">
 
 function toast({ ...props }: Toast) {
@@ -188,4 +194,4 @@ function useToast() {
   }
 }
 
-export { useToast, toast }
+export { useToast, toast, resetToasts }

--- a/client/src/lib/redirects.ts
+++ b/client/src/lib/redirects.ts
@@ -16,8 +16,10 @@ export const redirectMap: Record<string, string> = {
   '/health-care-marketing.php': '/services/healthcare-services',
   
   // Other potential legacy URLs
-  '/about': '/about-us', 
-  '/contact.php': '/contact',
+  '/about': '/about-us',
+  '/contact.php': '/contact-form',
+  '/contact': '/contact-form',
+  '/quote': '/contact-form',
   '/fulfillment.php': '/services/order-fulfillment',
   '/services.php': '/services',
   '/testimonials.php': '/testimonials',

--- a/client/src/pages/NewHome.tsx
+++ b/client/src/pages/NewHome.tsx
@@ -215,7 +215,7 @@ const NewHome: React.FC = () => {
           <Button 
             className="bg-white hover:bg-gray-100 text-[#0056B3] px-8 py-3 text-lg font-bold"
             onClick={() => {
-              window.location.href = '/quote';
+              window.location.href = '/contact-form';
             }}
           >
             Request a Quote
@@ -339,7 +339,7 @@ const NewHome: React.FC = () => {
               <Button 
                 className="bg-white hover:bg-gray-100 text-blue-800 font-bold px-8 py-3 text-lg"
                 onClick={() => {
-                  window.location.href = '/quote';
+                  window.location.href = '/contact-form';
                 }}
               >
                 Request a Quote

--- a/client/src/pages/OWDStyleHome.tsx
+++ b/client/src/pages/OWDStyleHome.tsx
@@ -95,7 +95,7 @@ const OWDStyleHome: React.FC = () => {
           </div>
           <div className="flex items-center gap-4">
             <a href="/login" className="hover:text-blue-200 transition">Client Login</a>
-            <a href="/contact" className="hover:text-blue-200 transition">Contact Us</a>
+            <a href="/contact-form" className="hover:text-blue-200 transition">Contact Us</a>
           </div>
         </div>
       </div>
@@ -211,10 +211,10 @@ const OWDStyleHome: React.FC = () => {
           <p className="text-xl mb-8 max-w-3xl mx-auto">
             Get in touch with our team for a customized fulfillment solution that meets your business needs.
           </p>
-          <Button 
+          <Button
             className="bg-white hover:bg-gray-100 text-blue-600 px-8 py-3 text-lg font-bold"
             onClick={() => {
-              window.location.href = '/quote';
+              window.location.href = '/contact-form';
             }}
           >
             Request a Quote
@@ -305,7 +305,7 @@ const OWDStyleHome: React.FC = () => {
                 <li><a href="/why-us" className="text-gray-400 hover:text-white transition-colors">Why Choose TSG</a></li>
                 <li><a href="/industries" className="text-gray-400 hover:text-white transition-colors">Industries We Serve</a></li>
                 <li><a href="/technology" className="text-gray-400 hover:text-white transition-colors">Technology</a></li>
-                <li><a href="/contact" className="text-gray-400 hover:text-white transition-colors">Contact Us</a></li>
+                <li><a href="/contact-form" className="text-gray-400 hover:text-white transition-colors">Contact Us</a></li>
               </ul>
             </div>
             
@@ -336,7 +336,7 @@ const OWDStyleHome: React.FC = () => {
                 </li>
               </ul>
               <div className="mt-6">
-                <a href="/quote">
+                <a href="/contact-form">
                   <Button className="bg-blue-600 hover:bg-blue-700 text-white px-6">
                     Request a Quote
                   </Button>

--- a/client/src/pages/QuoteButtonTest.tsx
+++ b/client/src/pages/QuoteButtonTest.tsx
@@ -171,10 +171,10 @@ const QuoteButtonTest: React.FC = () => {
               <div className="p-3 border rounded-lg">
                 <div className="flex items-center justify-between">
                   <div>
-                    <h4 className="font-medium">Contact Page (/contact)</h4>
+                    <h4 className="font-medium">Contact Page (/contact-form)</h4>
                     <p className="text-sm text-gray-600">Test: Quote form accessibility and functionality</p>
                   </div>
-                  <a href="/contact" className="text-blue-600 hover:underline text-sm">Visit Page</a>
+                  <a href="/contact-form" className="text-blue-600 hover:underline text-sm">Visit Page</a>
                 </div>
               </div>
             </div>

--- a/client/src/pages/ServiceDetail.tsx
+++ b/client/src/pages/ServiceDetail.tsx
@@ -528,7 +528,7 @@ const ServiceDetail = () => {
                 size="lg"
                 className="bg-primary hover:bg-primary/90"
                 onClick={() => {
-                  setLocation(`/quote?service=${encodeURIComponent(service.title)}`);
+                  setLocation(`/contact-form?service=${encodeURIComponent(service.title)}`);
                 }}
               >
                 Request a Quote
@@ -614,7 +614,7 @@ const ServiceDetail = () => {
                   size="lg"
                   className="bg-primary hover:bg-primary/90"
                   onClick={() => {
-                    setLocation(`/quote?service=${encodeURIComponent(service.title)}`);
+                    setLocation(`/contact-form?service=${encodeURIComponent(service.title)}`);
                   }}
                 >
                   Get Your Quote


### PR DESCRIPTION
## Summary
- consolidate quote/contact actions to `/contact-form`
- update links in layout, home pages, navbar and service details
- redirect old `/quote` and `/contact` routes
- adjust toast hook and tests

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_b_68410cc43900833084ac04ed7ad0c522