### PR TITLE
Remove duplicate employee route

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1027,24 +1027,6 @@ export async function registerRoutes(app: Express, analytics: boolean): Promise<
     }
   });
 
-  app.post("/api/employees", requireAuth, canManageUsers, async (req, res) => {
-    try {
-      const employeeData = insertEmployeeSchema.parse(req.body);
-      
-      // Hash password before storing
-      const hashedPassword = await hashPassword(employeeData.password);
-      const employee = await storage.createEmployee({
-        ...employeeData,
-        password: hashedPassword
-      });
-      
-      // Remove password from response
-      const { password, ...safeEmployee } = employee;
-      res.status(201).json(safeEmployee);
-    } catch (error) {
-      handleError(res, error, "Failed to create employee");
-    }
-  });
 
   app.patch("/api/employees/:id", requireAuth, canManageUsers, async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- remove second `/api/employees` POST route so only one employee creation endpoint exists

## Testing
- `npm test` *(fails: DATABASE_URL and other env vars not set)*

------
https://chatgpt.com/codex/tasks/task_b_6849f67a9b7883309484d0320832f9b9