### PR TITLE
Fix 32-bit masking in hashUserId

### DIFF
--- a/server/feature-flags.ts
+++ b/server/feature-flags.ts
@@ -184,7 +184,8 @@ class FeatureFlagService {
     for (let i = 0; i < str.length; i++) {
       const char = str.charCodeAt(i);
       hash = ((hash << 5) - hash) + char;
-      hash = hash & hash; // Convert to 32-bit integer
+      // Convert to 32-bit integer
+      hash = hash & 0xffffffff;
     }
     return Math.abs(hash);
   }


### PR DESCRIPTION
## Summary
- ensure `hashUserId` masks with `0xffffffff`

## Testing
- `npm test` *(fails: DATABASE_URL must be set, contact-form HelmetDispatcher error, failed routes tests)*

------
https://chatgpt.com/codex/tasks/task_b_6849fa65c2dc8330b3e31bd72fb6dc36